### PR TITLE
Use asciidoctor 1.5.3-preview.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "q": "^1.1.2",
         "lodash": "^3.2.0",
-        "asciidoctor.js": "1.5.2",
+        "asciidoctor.js": "1.5.3-preview.1",
         "cheerio": "^0.19.0"
     },
     "devDependencies": {


### PR DESCRIPTION
It contains a fix that makes it possible to install behind a proxy:
asciidoctor/asciidoctor.js@143a6867

Related issue: asciidoctor/asciidoctor.js#128