### PR TITLE
Support for parts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "lodash": "^3.2.0",
         "asciidoctor.js": "1.5.5-1",
-        "gitbook-html": "1.1.0"
+        "gitbook-html": "1.2.1"
     },
     "devDependencies": {
         "mocha": "2.3.2"

--- a/test/fixtures/SUMMARY-PARTS.adoc
+++ b/test/fixtures/SUMMARY-PARTS.adoc
@@ -1,0 +1,20 @@
+= Summary
+
+== Part 1
+
+. link:chapter-1/README.adoc[Chapter 1]
+. link:chapter-2/README.adoc[Chapter 2]
+. link:chapter-3/README.adoc[Chapter 3]
+. link:chapter-4/README.adoc[Chapter 4]
+
+'''
+
+. link:chapter-1/README.adoc[Chapter for untitled part]
+
+== Empty part
+
+== Part 2
+
+. link:chapter-1/README.adoc[Chapter for Part 2]
+
+

--- a/test/fixtures/SUMMARY.adoc
+++ b/test/fixtures/SUMMARY.adoc
@@ -10,3 +10,12 @@
 . link:chapter-4/README.adoc[Chapter 4]
 .. Unfinished article
 . Unfinished Chapter
+
+== Part 2
+
+. link:chapter-1/README.adoc[Chapter 1]
+
+
+'''
+
+. link:chapter-1/README.adoc[Chapter 1]

--- a/test/langs.js
+++ b/test/langs.js
@@ -13,10 +13,10 @@ describe('Languages parsing', function () {
     });
 
     it('should detect paths and titles', function() {
-        assert.equal(LEXED[0].path,'en/');
+        assert.equal(LEXED[0].ref,'en/');
         assert.equal(LEXED[0].title,'English');
 
-        assert.equal(LEXED[1].path,'fr/');
+        assert.equal(LEXED[1].ref,'fr/');
         assert.equal(LEXED[1].title,'French');
     });
 

--- a/test/summary.js
+++ b/test/summary.js
@@ -28,12 +28,12 @@ describe('Summary parsing', function () {
         assert.equal(PART.articles[2].articles.length, 0);
     });
 
-    it('should detect paths and titles', function() {
-        assert(PART.articles[0].path);
-        assert(PART.articles[1].path);
-        assert(PART.articles[2].path);
-        assert(PART.articles[3].path);
-        assert.equal(PART.articles[4].path, null);
+    it('should detect refs and titles', function() {
+        assert(PART.articles[0].ref);
+        assert(PART.articles[1].ref);
+        assert(PART.articles[2].ref);
+        assert(PART.articles[3].ref);
+        assert.equal(PART.articles[4].ref, null);
 
         assert(PART.articles[0].title);
         assert(PART.articles[1].title);
@@ -42,10 +42,10 @@ describe('Summary parsing', function () {
         assert(PART.articles[4].title);
     });
 
-    it('should normalize paths from .md', function() {
-        assert.equal(PART.articles[0].path,'chapter-1/README.adoc');
-        assert.equal(PART.articles[1].path,'chapter-2/README.adoc');
-        assert.equal(PART.articles[2].path,'chapter-3/README.adoc');
+    it('should normalize refs from .md', function() {
+        assert.equal(PART.articles[0].ref,'chapter-1/README.adoc');
+        assert.equal(PART.articles[1].ref,'chapter-2/README.adoc');
+        assert.equal(PART.articles[2].ref,'chapter-3/README.adoc');
     });
 
     it('should correctly convert it to text', function() {

--- a/test/summary.js
+++ b/test/summary.js
@@ -11,15 +11,36 @@ describe('Summary parsing', function () {
         var CONTENT = fs.readFileSync(path.join(__dirname, './fixtures/SUMMARY.adoc'), 'utf8');
         LEXED = summary(CONTENT);
         PART = LEXED.parts[0];
-        // todo: add support for parts in asciidoc
+
     });
 
-    it('should detect parts', function() {
-        assert.equal(LEXED.parts.length, 1);
+    describe('Parts', function() {
+        it('should detect parts', function() {
+            assert.equal(LEXED.parts.length, 3);
+        });
+
+        it('should detect title', function() {
+            assert.equal(LEXED.parts[0].title, '');
+            assert.equal(LEXED.parts[1].title, 'Part 2');
+            assert.equal(LEXED.parts[2].title, '');
+        });
+
+        it('should detect empty parts', function() {
+            var CONTENT_EMPTY = fs.readFileSync(
+                path.join(__dirname, './fixtures/SUMMARY-PARTS.adoc'), 'utf8');
+            var LEXED_EMPTY = summary(CONTENT_EMPTY);
+
+            assert.equal(LEXED_EMPTY.parts.length, 4);
+            assert.equal(LEXED_EMPTY.parts[2].title, 'Empty part');
+        });
     });
 
     it('should detect articles', function() {
         assert.equal(PART.articles.length, 5);
+    });
+
+    it('should detect chapters in other parts', function() {
+        assert.equal(LEXED.parts[1].articles.length, 1);
     });
 
     it('should support articles', function() {
@@ -42,7 +63,7 @@ describe('Summary parsing', function () {
         assert(PART.articles[4].title);
     });
 
-    it('should normalize refs from .md', function() {
+    it('should normalize paths from .adoc', function() {
         assert.equal(PART.articles[0].ref,'chapter-1/README.adoc');
         assert.equal(PART.articles[1].ref,'chapter-2/README.adoc');
         assert.equal(PART.articles[2].ref,'chapter-3/README.adoc');


### PR DESCRIPTION
Depending on https://github.com/GitbookIO/gitbook-html/pull/2

Now we can add parts in Summary:

```adoc
= Summary

== Part 1
. link:chapter-1/README.adoc[Chapter for Part 1]

== Part 2
. link:chapter-1/README.adoc[Chapter for Part 2]

'''
. link:chapter-1/README.adoc[Chapter for untitled part]

```