### PR TITLE
Add support for Font Awesome icons

### DIFF
--- a/lib/toHTML.js
+++ b/lib/toHTML.js
@@ -2,9 +2,11 @@ var asciidoctor = require('asciidoctor.js')();
 var opal = asciidoctor.Opal;
 var processor = asciidoctor.Asciidoctor(true);
 
+var attr = 'showtitle icons=@';
+
 // Render Asciidoc to HTML (block)
 function asciidocToHTML(content) {
-    var options = opal.hash2(['attributes'], {'attributes': 'showtitle'});
+    var options = opal.hash2(['attributes'], {'attributes': attr});
 
     var html = processor.$convert(content, options);
     return html;
@@ -12,7 +14,7 @@ function asciidocToHTML(content) {
 
 // Render Asciidoc to HTML (inline)
 function asciidocToHTMLInline(content) {
-    var options = Opal.hash({doctype: 'inline', attributes: ['showtitle']});
+    var options = Opal.hash({doctype: 'inline', attributes: [attr]});
 
     var html = processor.$convert(content, options);
     return html;


### PR DESCRIPTION
After the commit users should be able to add the `:icons: font` attribute in the asciidoc document to use Font Awesome. The user still need to add the Font Awesome assets by their own.

Issue: #10